### PR TITLE
Normalize version_id for minor versions, e.g. 100.2 < 100.20

### DIFF
--- a/src/main/resources/bin/registry.properties
+++ b/src/main/resources/bin/registry.properties
@@ -35,8 +35,8 @@
 # THIS FILE WILL GET OVERWRITTEN AT CONFIGURE TIME,
 # BEFORE CWS STARTS UP FOR THE FIRST TIME
 #
-maxShardsPerNode=3
-numShards=3
+maxShardsPerNode=1
+numShards=1
 replicationFactor=1
 solr.port=8983
 solr.host=localhost

--- a/src/main/resources/bin/registry_installer_docker.sh
+++ b/src/main/resources/bin/registry_installer_docker.sh
@@ -32,8 +32,8 @@
 
 SOLR_HEAP=2048m
 
-maxShardsPerNode=3
-numShards=3
+maxShardsPerNode=1
+numShards=1
 replicationFactor=1
 
 DOCKER_IMAGE=registry-legacy

--- a/src/main/resources/collections/data/managed-schema
+++ b/src/main/resources/collections/data/managed-schema
@@ -24,7 +24,8 @@
 
    <field name="identifier" type="string" indexed="true" stored="true" required="true" multiValued="true" />
    <field name="lid" type="string" indexed="true" stored="true" required="true" multiValued="false" />
-   <field name="version_id" type="pfloat" indexed="true" stored="true" multiValued="false" />
+   <field name="version_id" type="string" indexed="true" stored="true" multiValued="false" />
+   <field name="version_id_normalized" type="pfloat" indexed="true" stored="true" multiValued="false" />
    <field name="lidvid" type="string" indexed="true" stored="true" required="true" multiValued="false" />
    <field name="abstract_text" type="text_general" indexed="false" stored="true" multiValued="true" />
    <field name="agency_name" type="lowercase" indexed="true" stored="true" multiValued="true" />

--- a/src/main/resources/collections/data/solrconfig.xml
+++ b/src/main/resources/collections/data/solrconfig.xml
@@ -786,7 +786,7 @@
        <str name="f.facet_primary_result_processing_level.facet.prefix">1,</str>
 
        <!-- Update params to include filter query restricting to latest product versions -->
-      <str name="fq">{!collapse field=lid max=version_id}</str>
+      <str name="fq">{!collapse field=lid max=version_id_normalized}</str>
     </lst>
 
     <lst name="appends">
@@ -845,7 +845,7 @@
        <str name="f.facet_primary_result_processing_level.facet.prefix">1,</str>
 
       <!-- Update params to include filter query restricting to latest product versions -->
-      <str name="fq">{!collapse field=lid max=version_id}</str>
+      <str name="fq">{!collapse field=lid max=version_id_normalized}</str>
     </lst>
 
     <!-- Ignore superseded data sets by appending a filter to the query -->

--- a/src/main/resources/collections/data/xslt/add-hierarchy.xsl
+++ b/src/main/resources/collections/data/xslt/add-hierarchy.xsl
@@ -51,7 +51,16 @@
   <xsl:template match="field[@name = 'data_set_name']">
     <field name="data_set_name"><xsl:value-of select="pds:clean(.)" /></field>
   </xsl:template>
-
+  
+  <xsl:template match="field[@name = 'version_id']">
+    <field name="version_id"><xsl:value-of select="." /></field>
+    <xsl:variable name="major-version-string" select="substring-before(., '.')" />
+    <xsl:variable name="minor-version-string" select="substring-after(., '.')" />
+    <xsl:variable name="padded-minor-version-string" select="substring(string(100000 + xs:numeric($minor-version-string)), 2)" />
+    <xsl:variable name="normalized-numeric" select="number(concat($major-version-string, '.', $padded-minor-version-string))" />
+    <field name="version_id_normalized"><xsl:value-of select="number(format-number($normalized-numeric, '0.0000000'))" /></field>
+  </xsl:template>
+  
   <xsl:template match="field[@name = 'instrument_type']">
     <field name="instrument_type"><xsl:value-of select="pds:clean(.)" /></field>
   </xsl:template>


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary

**Note**: since this uses SolrCloud, it requires a single shard to use the `collapse` function

**Steps** for normalizing `version_id`:
- split `version_id` into major and minor versions
- pad the minor version
- concatenate the major and padded minor versions
- format the string to the maximum number of decimal places for a float
- convert to a number

**Examples** (preformatted for easier viewing of number of digits):
```
100.2 becomes
100.00002
100.20 becomes
100.0002
2.40 becomes
  2.0004
```

## ⚙️ Test Data and/or Report

[test_solr_doc.normalize_versions_good.xml.txt](https://github.com/NASA-PDS/registry-mgr-legacy/files/12807065/test_solr_doc.normalize_versions_good.xml.txt)


## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes NASA-PDS/registry-mgr-legacy#1
        - fixes NASA-PDS/registry-mgr-legacy#2
        - refs NASA-PDS/registry-mgr-legacy#3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Fixes https://github.com/NASA-PDS/registry-legacy-solr/issues/91
Known bug described in https://github.com/NASA-PDS/registry-legacy-solr/issues/82
