### PR TITLE
Update assembly .xml files for renamed commands

### DIFF
--- a/src/main/assembly/tar-assembly.xml
+++ b/src/main/assembly/tar-assembly.xml
@@ -44,9 +44,9 @@
       <outputDirectory>/bin/</outputDirectory>
       <includes>
       	<include>**/registry.properties</include>
-        <include>**/registry_installer_standalone.sh</include>
-        <include>**/registry_installer_docker.sh</include>
-        <include>**/registry-mgr</include>
+        <include>**/registry_legacy_installer_standalone.sh</include>
+        <include>**/registry_legacy_installer_docker.sh</include>
+        <include>**/registry-mgr-legacy</include>
       </includes>
       <fileMode>775</fileMode>
       <lineEnding>unix</lineEnding>

--- a/src/main/assembly/zip-assembly.xml
+++ b/src/main/assembly/zip-assembly.xml
@@ -44,11 +44,11 @@
       <outputDirectory>/bin/</outputDirectory>
       <includes>
       	<include>**/registry.properties</include>
-        <include>**/registry_installer_standalone.sh</include>
-        <include>**/registry_installer_docker.sh</include>
-        <include>**/registry-mgr</include>
-        <include>**/registry_install.bat</include>
-        <include>**/registry_uninstall.bat</include>
+        <include>**/registry_legacy_installer_standalone.sh</include>
+        <include>**/registry_legacy_installer_docker.sh</include>
+        <include>**/registry-mgr-legacy</include>
+        <include>**/registry_legacy_install.bat</include>
+        <include>**/registry_legacy_uninstall.bat</include>
       </includes>
       <fileMode>775</fileMode>
       <lineEnding>unix</lineEnding>


### PR DESCRIPTION
I'd missed these when renaming the command files, so they are not included in the application zip/tar when assembled.