### PR TITLE
Update result count xpaths to use numFound

### DIFF
--- a/src/main/resources/collections/data/xslt/data-search.xsl
+++ b/src/main/resources/collections/data/xslt/data-search.xsl
@@ -16,7 +16,7 @@
   <xsl:variable name="title">PDS: Search Results</xsl:variable>
   <xsl:variable name="ds_result_range">
     <xsl:choose>
-      <xsl:when test="//int/@ngroups &lt; 1">
+      <xsl:when test="//result/@numFound &lt; 1">
         <xsl:text />
       </xsl:when>
       <xsl:otherwise>
@@ -28,11 +28,11 @@
     </xsl:choose>
   </xsl:variable>
   <xsl:variable name="ds_result_count">
-    <xsl:value-of select="//int/@ngroups" />
+    <xsl:value-of select="//result/@numFound" />
   </xsl:variable>
   <xsl:variable name="ds_result_caption">
     <xsl:choose>
-      <xsl:when test="//int/@ngroups = 1">result</xsl:when>
+      <xsl:when test="//result/@numFound = 1">result</xsl:when>
       <xsl:otherwise>results</xsl:otherwise>
     </xsl:choose>
   </xsl:variable>
@@ -218,10 +218,10 @@
         
       </ul>
 
-      <xsl:if test="//lst/int/@ngroups &gt; count(//result/doc)">
+      <xsl:if test="//result/@numFound &gt; count(//result/doc)">
         <p style="margin-top: 1.5em; font-size: 120%;">Result pages:
           <xsl:variable name="q" select="response/lst[@name='responseHeader']/lst[@name='params']/str[@name='q']" />
-          <xsl:for-each select="pds:page-range(//lst/int/@ngroups,$start,$rows)">
+          <xsl:for-each select="pds:page-range(//result/@numFound,$start,$rows)">
             <xsl:text> &#160;</xsl:text>
             <xsl:choose>
               <xsl:when test=". = $start">
@@ -260,7 +260,7 @@
 
   </xsl:when>
   <xsl:otherwise>
-    <p>There are not results matching your query.</p>
+    <p>There are no results matching your query.</p>
   </xsl:otherwise>
 </xsl:choose>
 


### PR DESCRIPTION
## 🗒️ Summary
Per XML response, `//result/@numFound` has the hit count:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<response>

<lst name="responseHeader">
  <bool name="zkConnected">true</bool>
  <int name="status">0</int>
  <int name="QTime">18</int>
  <lst name="params">
    <str name="q">*:*</str>
    <str name="wt">xml</str>
  </lst>
</lst>
<result name="response" numFound="4401" start="0" maxScore="1.0" numFoundExact="true">
  <doc>
```

## ⚙️ Test Data and/or Report
* Load some data into registry
* Test response
* See screenshots from testing on staging server

<img width="972" alt="Screenshot 2024-02-23 at 10 31 18 AM" src="https://github.com/NASA-PDS/registry-mgr-legacy/assets/33492486/7d2feb82-f642-4bc3-8a06-36691f206731">

<img width="798" alt="Screenshot 2024-02-23 at 10 31 24 AM" src="https://github.com/NASA-PDS/registry-mgr-legacy/assets/33492486/d66af1df-1f5c-4bfc-ac2d-ed61f9f92c68">


## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes NASA-PDS/registry-mgr-legacy#1
        - fixes NASA-PDS/registry-mgr-legacy#2
        - refs NASA-PDS/registry-legacy-solr#84
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Resolves NASA-PDS/registry-legacy-solr#87

